### PR TITLE
Stop persisting submissions to disk; mirror submitted JSON in DOM via…

### DIFF
--- a/app.py
+++ b/app.py
@@ -399,29 +399,10 @@ def order_request():
 
 # 添加辅助函数
 def save_submission_to_json(template_name, data):
-    """将提交的数据保存到对应的JSON文件中"""
-    # 确保submission文件夹存在
-    if not os.path.exists('submission'):
-        os.makedirs('submission')
-    
-    # 构建JSON文件路径
-    filename = f"submission/{template_name.replace('.html', '')}.json"
-    
-    # 添加时间戳
+    """No-op: previously wrote to disk; now mirrored into DOM by pages."""
+    # Preserve prior side-effect of adding a timestamp if downstream expects it
     data['submission_time'] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    
-    # 读取现有数据或创建新的数据列表
-    submissions = []
-    if os.path.exists(filename):
-        with open(filename, 'r', encoding='utf-8') as f:
-            submissions = json.load(f)
-    
-    # 添加新提交的数据
-    submissions.append(data)
-    
-    # 保存更新后的数据
-    with open(filename, 'w', encoding='utf-8') as f:
-        json.dump(submissions, f, ensure_ascii=False, indent=4)
+    return
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/templates/A12.html
+++ b/templates/A12.html
@@ -18,6 +18,8 @@
         <form id="dynamicForm" method="POST">
             <!-- 表单字段将通过 JavaScript 动态生成 -->
         </form>
+        <!-- Hidden field to store last submitted JSON for this page -->
+        <input type="hidden" id="selected-answer">
         <button type="submit" form="dynamicForm" class="btn btn-primary">Submit</button>
     </div>
 
@@ -26,6 +28,15 @@
         document.getElementById('dynamicForm').addEventListener('submit', function(e) {
             e.preventDefault();
             const formData = new FormData(this);
+            // Mirror submitted data into DOM hidden field (JSON string)
+            (function(){
+                const obj = {};
+                for (const [k,v] of formData.entries()){
+                    obj[k] = v instanceof File ? (v.name || '') : v;
+                }
+                const el = document.getElementById('selected-answer');
+                if (el) el.value = JSON.stringify(obj);
+            })();
             
             fetch(window.location.href, {
                 method: 'POST',

--- a/templates/A14.html
+++ b/templates/A14.html
@@ -61,10 +61,28 @@
             <!-- 提交按钮 -->
             <button type="submit" class="btn btn-primary">Submit Paper</button>
         </form>
+        <input type="hidden" id="selected-answer">
     </div>
 
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.2/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+    (function(){
+        var form = document.querySelector('form');
+        if (!form) return;
+        form.addEventListener('submit', function(){
+            try{
+                var fd = new FormData(form);
+                var obj = {};
+                for (const [k,v] of fd.entries()){
+                    obj[k] = v instanceof File ? (v.name || '') : v;
+                }
+                var el = document.getElementById('selected-answer');
+                if (el) el.value = JSON.stringify(obj);
+            }catch(_){ }
+        }, true);
+    })();
+    </script>
 </body>
 </html>

--- a/templates/A15.html
+++ b/templates/A15.html
@@ -129,11 +129,29 @@
                 <button type="submit" class="btn btn-primary btn-lg">Submit Registration</button>
             </div>
         </form>
+        <input type="hidden" id="selected-answer">
     </div>
 
     <script src="https://code.jquery.com/jquery-3.5.1.slim.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/@popperjs/core@2.5.2/dist/umd/popper.min.js"></script>
     <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+    <script>
+    (function(){
+        var form = document.querySelector('form');
+        if (!form) return;
+        form.addEventListener('submit', function(){
+            try{
+                var fd = new FormData(form);
+                var obj = {};
+                for (const [k,v] of fd.entries()){
+                    obj[k] = v instanceof File ? (v.name || '') : v;
+                }
+                var el = document.getElementById('selected-answer');
+                if (el) el.value = JSON.stringify(obj);
+            }catch(_){ }
+        }, true);
+    })();
+    </script>
 </body>
 </html>
 ```

--- a/templates/base.html
+++ b/templates/base.html
@@ -10,8 +10,38 @@
     <div class="container mt-5">
         {% block content %}{% endblock %}
     </div>
+    <!-- Hidden field to store last submitted JSON across pages -->
+    <input type="hidden" id="selected-answer">
+
     <script src="{{ url_for('static', filename='js/jquery-3.5.1.slim.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/popper.min.js') }}"></script>
     <script src="{{ url_for('static', filename='js/bootstrap.min.js') }}"></script>
+    <script>
+    (function(){
+        // Attach to all forms without changing visible behavior
+        function toJSON(form){
+            const fd = new FormData(form);
+            const obj = {};
+            for (const [k,v] of fd.entries()){
+                if (v instanceof File) {
+                    obj[k] = v.name || '';
+                } else {
+                    obj[k] = v;
+                }
+            }
+            return JSON.stringify(obj);
+        }
+        function setHidden(json){
+            var el = document.getElementById('selected-answer');
+            if (el) el.value = json;
+        }
+        window.addEventListener('submit', function(e){
+            // Do not prevent default; only mirror data into DOM
+            if (e.target && e.target.tagName === 'FORM'){
+                try { setHidden(toJSON(e.target)); } catch(_){}
+            }
+        }, true);
+    })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
… hidden #selected-answer.\n- Make save_submission_to_json a no-op (keep timestamp in response)\n- Add hidden field + global submit listener in base.html\n- Add page-local mirrors for standalone A12/A14/A15\n- Preserve all visible behavior and submit flows